### PR TITLE
ci: harden workflows with least-privilege token and concurrency

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,8 +1,13 @@
-# SPDX-FileCopyrightText: 2025 David Rabkin
+# SPDX-FileCopyrightText: 2025-2026 David Rabkin
 # SPDX-License-Identifier: 0BSD
 ---
 name: actionlint
 'on': [pull_request, push]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   URL: https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash # yamllint disable-line
 jobs:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,8 +1,13 @@
-# SPDX-FileCopyrightText: 2025 David Rabkin
+# SPDX-FileCopyrightText: 2025-2026 David Rabkin
 # SPDX-License-Identifier: 0BSD
 ---
 name: reuse
 'on': [pull_request, push]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   reuse:
     runs-on: ubuntu-24.04

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,8 +1,13 @@
-# SPDX-FileCopyrightText: 2025 David Rabkin
+# SPDX-FileCopyrightText: 2025-2026 David Rabkin
 # SPDX-License-Identifier: 0BSD
 ---
 name: typos
 'on': [pull_request, push]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   typos:
     runs-on: ubuntu-24.04

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,8 +1,13 @@
-# SPDX-FileCopyrightText: 2025 David Rabkin
+# SPDX-FileCopyrightText: 2025-2026 David Rabkin
 # SPDX-License-Identifier: 0BSD
 ---
 name: yamllint
 'on': [pull_request, push]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   yamllint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Hardens all four GitHub Actions workflows (actionlint, reuse, typos, yamllint):

- **Least-privilege token**: add `permissions: contents: read` so workflows no longer run with the default read/write `GITHUB_TOKEN`.
- **Concurrency**: add a `concurrency` group keyed on workflow + ref with `cancel-in-progress: true`, so superseded runs (e.g. rapid pushes to a PR) are cancelled instead of piling up.
- **Metadata**: bump the SPDX copyright year to `2025-2026` on each changed file.

No behavioral change to what the linters check. No portability implications. Validated locally: `yamllint -s` and `actionlint` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to enhance security posture and optimize concurrency handling across continuous integration pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->